### PR TITLE
Improved support for DateTime filtering

### DIFF
--- a/DotnetStandardQueryBuilder.MemoryList/FilterBuilder.cs
+++ b/DotnetStandardQueryBuilder.MemoryList/FilterBuilder.cs
@@ -127,32 +127,48 @@
                         return !JToken.DeepEquals(document.GetValueIgnoreCase(filterColumn), JToken.FromObject(filterValue));
 
                     case FilterOperator.IsGreaterThan:
-                        if (!filterValue.IsNumeric())
+                        if (filterValue.IsNumeric())
                         {
-                            return false;
+                            return document.GetValueIgnoreCase(filterColumn).ToObject<long>() > Convert.ToInt64(filterValue);
                         }
-                        return document.GetValueIgnoreCase(filterColumn).ToObject<long>() > Convert.ToInt64(filterValue);
+                        else if (document.GetValueIgnoreCase(filterColumn).Type is JTokenType.Date)
+                        {
+                            return document.GetValueIgnoreCase(filterColumn).ToObject<DateTime>() > Convert.ToDateTime(filterValue);
+                        }
+                        return false;
 
                     case FilterOperator.IsGreaterThanOrEqualTo:
-                        if (!filterValue.IsNumeric())
+                        if (filterValue.IsNumeric())
                         {
-                            return false;
+                            return document.GetValueIgnoreCase(filterColumn).ToObject<long>() >= Convert.ToInt64(filterValue);
                         }
-                        return document.GetValueIgnoreCase(filterColumn).ToObject<long>() >= Convert.ToInt64(filterValue);
+                        else if (document.GetValueIgnoreCase(filterColumn).Type is JTokenType.Date)
+                        {
+                            return document.GetValueIgnoreCase(filterColumn).ToObject<DateTime>() >= Convert.ToDateTime(filterValue);
+                        }
+                        return false;
 
                     case FilterOperator.IsLessThan:
-                        if (!filterValue.IsNumeric())
+                        if (filterValue.IsNumeric())
                         {
-                            return false;
+                            return document.GetValueIgnoreCase(filterColumn).ToObject<long>() < Convert.ToInt64(filterValue);
                         }
-                        return document.GetValueIgnoreCase(filterColumn).ToObject<long>() < Convert.ToInt64(filterValue);
+                        else if (document.GetValueIgnoreCase(filterColumn).Type is JTokenType.Date)
+                        {
+                            return document.GetValueIgnoreCase(filterColumn).ToObject<DateTime>() < Convert.ToDateTime(filterValue);
+                        }
+                        return false;
 
                     case FilterOperator.IsLessThanOrEqualTo:
-                        if (!filterValue.IsNumeric())
+                        if (filterValue.IsNumeric())
                         {
-                            return false;
+                            return document.GetValueIgnoreCase(filterColumn).ToObject<long>() <= Convert.ToInt64(filterValue);
                         }
-                        return document.GetValueIgnoreCase(filterColumn).ToObject<long>() <= Convert.ToInt64(filterValue);
+                        else if (document.GetValueIgnoreCase(filterColumn).Type is JTokenType.Date)
+                        {
+                            return document.GetValueIgnoreCase(filterColumn).ToObject<DateTime>() <= Convert.ToDateTime(filterValue);
+                        }
+                        return false;
 
                     case FilterOperator.Contains:
                         if (filterValue is not string)

--- a/DotnetStandardQueryBuilder.MemoryList/ValueBuilder.cs
+++ b/DotnetStandardQueryBuilder.MemoryList/ValueBuilder.cs
@@ -18,10 +18,6 @@
             {
                 return Convert.ToString(_value);
             }
-            else if (typeof(DateTime) == _value.GetType())
-            {
-                return Convert.ToDateTime(_value).Date;
-            }
             else if (_value is bool)
             {
                 return Convert.ToBoolean(_value);

--- a/DotnetStandardQueryBuilder.UnitTest/MemoryList/MemoryListQueryBuilder_Query.cs
+++ b/DotnetStandardQueryBuilder.UnitTest/MemoryList/MemoryListQueryBuilder_Query.cs
@@ -40,6 +40,14 @@ namespace DotnetStandardQueryBuilder.UnitTest.Mongo
 
             Assert.AreEqual(result.Count, 3);
 
+            result = new MemoryListQueryBuilder<SampleModel>(SampleRequest.DateTimeEq, SampleModel.SampleItems).Query();
+
+            Assert.AreEqual(result.Count, 1);
+
+            result = new MemoryListQueryBuilder<SampleModel>(SampleRequest.DateTimeBetween, SampleModel.SampleItems).Query();
+
+            Assert.AreEqual(result.Count, 1);
+
             var count = new MemoryListQueryBuilder<SampleModel>(SampleRequest.PageSizeNull, SampleModel.SampleItems).QueryCount();
 
             Assert.AreEqual(count, 3);

--- a/DotnetStandardQueryBuilder.UnitTest/SampleModel.cs
+++ b/DotnetStandardQueryBuilder.UnitTest/SampleModel.cs
@@ -1,5 +1,6 @@
 ﻿namespace DotnetStandardQueryBuilder
 {
+    using System;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
 
@@ -25,6 +26,8 @@
 
         public SampleEnum EnumValue { get; set; }
 
+        public DateTime DateTimeValue { get; set; }
+
         public static List<SampleModel> SampleItems = new List<SampleModel>
             {
                 new SampleModel
@@ -33,7 +36,8 @@
                     Name = "name",
                     ParentId = new int[]{ 100, 200, 300 },
                     FirstName = "firstName",
-                    Value = 200
+                    Value = 200,
+                    DateTimeValue = new DateTime(2021, 8, 29, 21, 42, 42)
                 },
                 new SampleModel
                 {
@@ -41,7 +45,8 @@
                     Name = "Nikhil Sarvaiye",
                     ParentId = new int[]{ 100 },
                     FirstName = "Sarvaiye",
-                    Value = 10
+                    Value = 10,
+                    DateTimeValue = new DateTime(2022, 8, 29, 21, 42, 42)
                 },
                 new SampleModel
                 {
@@ -49,7 +54,8 @@
                     Name = "Dotnet Standard",
                     ParentId = new int[]{ },
                     FirstName = "Dotnet",
-                    Value = 100
+                    Value = 100,
+                    DateTimeValue = new DateTime(2022, 8, 29, 4, 18, 0)
                 }
             };
     }

--- a/DotnetStandardQueryBuilder.UnitTest/SampleRequest.cs
+++ b/DotnetStandardQueryBuilder.UnitTest/SampleRequest.cs
@@ -1,7 +1,8 @@
 ﻿namespace DotnetStandardQueryBuilder.UnitTest
 {
-    using DotnetStandardQueryBuilder.Core;
+    using System;
     using System.Collections.Generic;
+    using DotnetStandardQueryBuilder.Core;
 
     public static class SampleRequest
     {
@@ -256,6 +257,47 @@
             Page = 1,
             PageSize = 20,
             Sorts = new List<Sort>() { new Sort { Direction = SortDirection.Ascending, Property = "name" }, new Sort { Direction = SortDirection.Descending, Property = "id" } },
+        };
+
+        public static Request DateTimeEq = new Request
+        {
+            Select = new List<string> { "id", "name" },
+            Page = 1,
+            PageSize = 20,
+            Sorts = new List<Sort>() { new Sort { Direction = SortDirection.Descending, Property = "name" }, new Sort { Direction = SortDirection.Descending, Property = "id" } },
+            Filter = new Filter
+            {
+                Property = "dateTimeValue",
+                Value = DateTime.Parse("2022-08-29 21:42:42"),
+                Operator = FilterOperator.IsEqualTo
+            },
+        };
+
+        public static Request DateTimeBetween = new Request
+        {
+            Select = new List<string> { "id", "name" },
+            Page = 1,
+            PageSize = 20,
+            Sorts = new List<Sort>() { new Sort { Direction = SortDirection.Descending, Property = "name" }, new Sort { Direction = SortDirection.Descending, Property = "id" } },
+            Filter = new CompositeFilter
+            {
+                LogicalOperator = LogicalOperator.And,
+                Filters = new List<IFilter>
+                {
+                    new Filter
+                    {
+                        Property = "dateTimeValue",
+                        Value = DateTime.Parse("2022-08-29 20:00:00"),
+                        Operator = FilterOperator.IsGreaterThanOrEqualTo
+                    },
+                    new Filter
+                    {
+                        Property = "dateTimeValue",
+                        Value =DateTime.Parse( "2022-08-29 23:59:59"),
+                        Operator = FilterOperator.IsLessThanOrEqualTo
+                    }
+                }
+            },
         };
     }
 }


### PR DESCRIPTION
This PR improves support for DateTime filtering using the `IsGreaterThan`, `IsGreaterThanOrEqualTo`, `IsLessThan`, `IsLessThanOrEqualTo` operators and closes #5. 
There is a breaking change in that the Time part isn't dropped from the `filterValue` anymore. This should be done beforehand or use a CompositeFilter like the following.

``` C#
new CompositeFilter
{
    LogicalOperator = LogicalOperator.And,
    Filters = new List<IFilter>
    {
        new Filter
        {
            Property = "dateTimeProperty",
            Value = DateTime.Parse("2022-08-29 00:00:00"),
            Operator = FilterOperator.IsGreaterThanOrEqualTo
        },
        new Filter
        {
            Property = "dateTimeProperty",
            Value =DateTime.Parse( "2022-08-29 23:59:59"),
            Operator = FilterOperator.IsLessThanOrEqualTo
        }
    }
}
```